### PR TITLE
Add dhall-prometheus-operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ A curated list of awesome dhall-lang binding, libraries and anything related to 
 - [dhall-bhat](https://github.com/FormationAI/dhall-bhat/) - Abstractions
 - [github-actions-dhall](https://github.com/vmchale/github-actions-dhall) - Dhall helpers for github actions 
 - [dhall-kops](https://github.com/coralogix/dhall-kops) - Dhall types for Kops
+- [dhall-prometheus-operator](https://github.com/coralogix/dhall-prometheus-operator) - Dhall types for the Prometheus Operator
 
 ## Projects
 - [spago](https://github.com/spacchetti/spago) - PureScript package manager and build tool powered by Dhall and package-sets


### PR DESCRIPTION
Adds [dhall-prometheus-operator](https://github.com/coralogix/dhall-prometheus-operator), which hosts Dhall types for the [Prometheus Operator](https://github.com/coreos/prometheus-operator).