### PR TITLE
Add dhall-security-txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ A curated list of awesome dhall-lang binding, libraries and anything related to 
 - [dhall-to-cabal](https://github.com/dhall-lang/dhall-to-cabal)
 - [dhall-nix](https://github.com/dhall-lang/dhall-haskell/tree/master/dhall-nix)
 - [dhall-bash](https://github.com/dhall-lang/dhall-haskell/tree/master/dhall-bash)
+- [dhall-security-txt](https://github.com/coralogix/dhall-security-txt)
 
 ## Libraries
 - [dhall-prelude](https://github.com/dhall-lang/dhall-lang/tree/master/Prelude) - Standard Libraries for dhall


### PR DESCRIPTION
Adds [dhall-security-txt](https://github.com/coralogix/dhall-security-txt), which models [security.txt](https://securitytxt.org/).

I wrote this (apparently six months ago) as an exercise in using Dhall to output a custom configuration format using `dhall text`. We aren't using it right now, which is why the formatting is out of date and it doesn't combine types and `render` functions in a single `package.dhall`, but the conciseness of the `security.txt` standard makes it really simple to model and makes it a great example of using `dhall text` for non-JSON/YAML purposes.