### PR TITLE
Add dhall-concourse

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ A curated list of awesome dhall-lang binding, libraries and anything related to 
 - [dhall-openssl](https://github.com/jvanbruegge/dhall-openssl) - Generate a type-safe openssl configuration file with dhall.
 - [nats.dhall](https://github.com/wallyqs/nats.dhall) - Dhall types to setup NATS.io on Kubernetes.
 - [dhall-ansible](https://github.com/TristanCacqueray/dhall-ansible) - Dhall types for Ansible.
+- [dhall-concourse](https://github.com/coralogix/dhall-concourse) - Dhall types for Concourse.
 
 ## Projects
 - [spago](https://github.com/spacchetti/spago) - PureScript package manager and build tool powered by Dhall and package-sets.


### PR DESCRIPTION
We've pulled this project out of its dormant status now that we can build a pipeline with it in a couple of seconds :tada: 

Regarding coralogix/dhall-concourse vs. akshaymankar/dhall-concourse, I do consider our implementation to be better because:
* coralogix/dhall-concourse keeps type-safety for resource sources
* coralogix/dhall-concourse adopts a novel approach to the recursive types problem which does not require the same type to be provided for each step hook (i.e. `on_success`, `on_failure`, etc.).