### PR TITLE
Use correct upstream repo for `dhall-ansible`

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ A curated list of awesome dhall-lang binding, libraries and anything related to 
 - [dhall-genode](https://git.sr.ht/~ehmry/dhall-genode) - Genode OS configuration types and functions.
 - [dhall-openssl](https://github.com/jvanbruegge/dhall-openssl) - Generate a type-safe openssl configuration file with dhall.
 - [nats.dhall](https://github.com/wallyqs/nats.dhall) - Dhall types to setup NATS.io on Kubernetes.
-- [dhall-ansible](https://github.com/TristanCacqueray/dhall-ansible) - Dhall types for Ansible.
+- [dhall-ansible](https://github.com/softwarefactory-project/dhall-ansible) - Dhall types for Ansible.
 - [dhall-concourse](https://github.com/coralogix/dhall-concourse) - Dhall types for Concourse.
 - [dhall-dot](https://github.com/Gabriel439/dhall-dot) - Dhall types and renderer for the DOT Graph description language.
 


### PR DESCRIPTION
The upstream `dhall-ansible` repository has been moved to a new
location.