### PR TITLE
Add regadas/github-actions-dhall

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ A curated list of awesome dhall-lang binding, libraries and anything related to 
 - [dhall-nethack](https://github.com/dhall-lang/dhall-nethack) - Generate NetHack configurations using Dhall.
 - [dada](https://github.com/sellout/dada) - Recursion schemes.
 - [dhall-bhat](https://github.com/FormationAI/dhall-bhat/) - Abstractions.
-- [github-actions-dhall](https://github.com/vmchale/github-actions-dhall) - Dhall helpers for GitHub actions.
+- [vmchale/github-actions-dhall](https://github.com/vmchale/github-actions-dhall) - Dhall helpers for GitHub actions.
+- [regadas/github-actions-dhall](https://github.com/regadas/github-actions-dhall) - Typecheck, template and modularize your Github Action definitions with Dhall.
 - [dhall-kops](https://github.com/coralogix/dhall-kops) - Dhall types for Kops.
 - [dhall-prometheus-operator](https://github.com/coralogix/dhall-prometheus-operator) - Dhall types for the Prometheus Operator.
 - [dhall-genode](https://git.sr.ht/~ehmry/dhall-genode) - Genode OS configuration types and functions.


### PR DESCRIPTION
Just found this repo and realized there's a lib with the same name 😅 it has a different take on it though. Assuming it's ok to add this here I'm not sure how to address the duplicate name.