### PR TITLE
Add `dhall-tsconfig`

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ A curated list of awesome dhall-lang binding, libraries and anything related to 
 - [dhall-openstacksdk](https://github.com/softwarefactory-project/dhall-openstacksdk) - Dhall types for OpenStack clouds.yaml.
 - [dhall-nomad](https://github.com/seatgeek/dhall-nomad) - Dhall types for HashiCorp's Nomad job scheduler
 - [dhall-aws-cloudformation](https://github.com/jcouyang/dhall-aws-cloudformation) - Dhall types for AWS CloudFormation
+- [dhall-tsconfig](https://github.com/maxdeviant/dhall-tsconfig) - Dhall bindings for [TSConfig](https://www.typescriptlang.org/tsconfig).
 
 ## Projects
 - [spago](https://github.com/spacchetti/spago) - PureScript package manager and build tool powered by Dhall and package-sets.


### PR DESCRIPTION
This PR adds an entry for `dhall-tsconfig`, which contains bindings for TypeScript's `tsconfig.json`.