### PR TITLE
Remove spago

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ A curated list of awesome dhall-lang binding, libraries and anything related to 
 - [dhall-tsconfig](https://github.com/maxdeviant/dhall-tsconfig) - Dhall bindings for [TSConfig](https://www.typescriptlang.org/tsconfig).
 
 ## Projects
-- [spago](https://github.com/spacchetti/spago) - PureScript package manager and build tool powered by Dhall and package-sets.
 - [cpkg](https://github.com/vmchale/cpkg) - A build tool/package manager for C, configured with Dhall.
 
 ## Miscellaneous


### PR DESCRIPTION
As far as I understand Spago moved to YAML, see https://github.com/purescript/spago/issues/842#issuecomment-1262935534.

The Dhall-based version is still available here https://github.com/purescript/spago-legacy, but I don't think having a deprecated project on an awesome list is a good idea.