### PR TITLE
Add project Updo

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ A curated list of awesome dhall-lang binding, libraries and anything related to 
 
 ## Projects
 - [cpkg](https://github.com/vmchale/cpkg) - A build tool/package manager for C, configured with Dhall.
+- [updo](https://github.com/cabalism/updo) - From Dhall configuration, generate Stack and Cabal projects with Dhall text templating.
 
 ## Miscellaneous
 - [dhall-vim](https://github.com/vmchale/dhall-vim) - Syntax highlighting in Vim for Dhall.


### PR DESCRIPTION
Please add Updo.

* [Announcing Updo](https://blockscope.com/posts/2023-11-15-updo.html) post linked in this week's Haskell Weekly [issue 394](https://github.com/cabalism/updo)
* Comes with a detailed [README](https://github.com/cabalism/updo#readme)
* Examples can be found at [up-do/repositories](https://github.com/orgs/up-do/repositories), some done and others are works in progress